### PR TITLE
fix for: A specified parameter was not correct: startOffset

### DIFF
--- a/internal/vmware_nbdkit/vmware_nbdkit.go
+++ b/internal/vmware_nbdkit/vmware_nbdkit.go
@@ -295,7 +295,7 @@ func (s *NbdkitServer) IncrementalCopyToTarget(ctx context.Context, t target.Tar
 			}
 		}
 
-		startOffset += diskChangeInfo.StartOffset + diskChangeInfo.Length
+		startOffset = diskChangeInfo.StartOffset + diskChangeInfo.Length
 		bar.Set64(startOffset)
 
 		if startOffset == s.Disk.CapacityInBytes {


### PR DESCRIPTION
This pr fixes a #24

I set "startOffset" to "diskChangeInfo.StartOffset + diskChangeInfo.Length" and do not increment it.