### PR TITLE
Using the device (disk) key instead of diskObjectId Issue/38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go build -o /migratekit main.go
 FROM fedora:40
 ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
 RUN \
-  dnf install -y nbdkit nbdkit-vddk-plugin libnbd virt-v2v virtio-win && \
+  dnf install --refresh -y nbdkit nbdkit-vddk-plugin libnbd virt-v2v virtio-win && \
   dnf clean all && \
   rm -rf /var/cache/dnf
 COPY --from=build /migratekit /usr/local/bin/migratekit

--- a/internal/openstack/util.go
+++ b/internal/openstack/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/gosimple/slug"
 	"github.com/vmware/govmomi/object"
@@ -41,5 +42,11 @@ func GetCurrentInstanceUUID() (string, error) {
 }
 
 func VolumeName(vm *object.VirtualMachine, disk *types.VirtualDisk) string {
-	return slug.Make(vm.Name() + "-" + disk.DiskObjectId)
+	return slug.Make(vm.Name() + "-" + strconv.Itoa(int(disk.Key)))
+}
+
+// ensuring backward compatibility
+// TODO: remove
+func VolumeNameOld(vm *object.VirtualMachine, disk *types.VirtualDisk) string {
+	return slug.Make(vm.Name() + "-" + string(disk.DiskObjectId))
 }

--- a/internal/target/openstack.go
+++ b/internal/target/openstack.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -73,7 +74,7 @@ func (t *OpenStack) Connect(ctx context.Context) error {
 	volumeMetadata := map[string]string{
 		"migrate_kit": "true",
 		"vm":          t.VirtualMachine.Reference().Value,
-		"disk":        t.Disk.DiskObjectId,
+		"disk":        strconv.Itoa(int(t.Disk.Key)),
 	}
 
 	opts := ctx.Value("volumeCreateOpts").(*VolumeCreateOpts)

--- a/internal/target/util.go
+++ b/internal/target/util.go
@@ -3,6 +3,7 @@ package target
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	"github.com/gosimple/slug"
 	log "github.com/sirupsen/logrus"
@@ -12,7 +13,7 @@ import (
 )
 
 func DiskLabel(vm *object.VirtualMachine, disk *types.VirtualDisk) string {
-	return slug.Make(vm.Name() + "-" + disk.DiskObjectId)
+	return slug.Make(vm.Name() + "-" + strconv.Itoa(int(disk.Key)))
 }
 
 func NeedsFullCopy(ctx context.Context, t Target) (bool, bool, error) {


### PR DESCRIPTION
The "diskObjectId" is not static and changes when a VM is migrated to another ESXi server within a cluster.
Then the incremental copy will not work. 

The device key is unique for a VM. In combination with the VM name, it is suitable as an identifier to map disks from VMware to Openstack volumes.

This PR changes the behavior of migratekit  to use the device key while maintaining a fallback if an incremental copy was done on a VM before these changes. It fixes #38 

