### PR TITLE
Fix #69 - Add --os-type option to set the os_type in the volume image metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ There are a few optional flags to define the following:
    `--disk-bus-type`: Flag to define volume disk bus type, currently only supports
                      scsi and virtio.
 -   `--compression-method`: Compression method: skipz, zlib and none.
+-   `--os-type`: Sets the "os_type" volume (image) metadata variable.
+                 If set to "auto", it tries to recognize the correct operating
+                 system via the VMware GuestId.
+                 Valid values for the most OpenStack installations are "linux"
+                 and "windows"
 
 ## Contributing
 

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ var (
 	enablev2v            bool
 	busType              BusTypeOpts
 	vzUnsafeVolumeByName bool
+	osType               string
 )
 
 var rootCmd = &cobra.Command{
@@ -192,6 +193,8 @@ var rootCmd = &cobra.Command{
 		ctx = context.WithValue(ctx, "volumeCreateOpts", &v)
 
 		ctx = context.WithValue(ctx, "vzUnsafeVolumeByName", vzUnsafeVolumeByName)
+
+		ctx = context.WithValue(ctx, "osType", osType)
 
 		cmd.SetContext(ctx)
 
@@ -343,6 +346,8 @@ func init() {
 	rootCmd.PersistentFlags().Var(enumflag.New(&busType, "disk-bus-type", BusTypeOptsIds, enumflag.EnumCaseInsensitive), "disk-bus-type", "Specifies the type of disk controller to attach disk devices to.")
 
 	rootCmd.PersistentFlags().BoolVar(&vzUnsafeVolumeByName, "vz-unsafe-volume-by-name", false, "Only use the name to find a volume - workaround for virtuozzu - dangerous option")
+
+    rootCmd.PersistentFlags().StringVar(&osType, "os-type", "", "Set os_type in the volume (image) metadata, (if set to \"auto\", it tries to detect the type from VMware GuestId)")
 
 	cutoverCmd.Flags().StringVar(&flavorId, "flavor", "", "OpenStack Flavor ID")
 	cutoverCmd.MarkFlagRequired("flavor")


### PR DESCRIPTION
This pull request add the --os-type option to set os_type in the volume image metadata to fix #69.

-   `--os-type`: Sets the "os_type" volume (image) metadata variable.
                 If set to "auto", it tries to recognize the correct operating
                 system via the VMware GuestId.
                 Valid values for the most OpenStack installations are "linux"
                 and "windows"