### PR TITLE
Fix #73 - add: enable-qemu-guest-agent parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ There are a few optional flags to define the following:
                  system via the VMware GuestId.
                  Valid values for the most OpenStack installations are "linux"
                  and "windows"
+-   `--enable-qemu-guest-agent`: Sets the "hw_qemu_guest_agent" volume (image) metadata parameter to "yes".
 
 ## Contributing
 

--- a/internal/target/openstack.go
+++ b/internal/target/openstack.go
@@ -136,6 +136,14 @@ func (t *OpenStack) Connect(ctx context.Context) error {
                 }).Info("Volume set os type")
             }
 
+            if ctx.Value("enableQemuGuestAgent").(bool) {
+                log.WithFields(log.Fields{
+                    "volume_id": volume.ID,
+                    "hw_qemu_guest_agent":   "yes",
+                }).Info("Volume enable qemu quest agent metadata parameter")
+                volumeImageMetadata["hw_qemu_guest_agent"] = "yes"
+            }
+
 			if types.GuestOsDescriptorFirmwareType(o.Config.Firmware) == types.GuestOsDescriptorFirmwareTypeEfi {
 				log.WithFields(log.Fields{
 					"volume_id": volume.ID,

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ var (
 	busType              BusTypeOpts
 	vzUnsafeVolumeByName bool
 	osType               string
+    enableQemuGuestAgent bool
 )
 
 var rootCmd = &cobra.Command{
@@ -195,6 +196,8 @@ var rootCmd = &cobra.Command{
 		ctx = context.WithValue(ctx, "vzUnsafeVolumeByName", vzUnsafeVolumeByName)
 
 		ctx = context.WithValue(ctx, "osType", osType)
+
+		ctx = context.WithValue(ctx, "enableQemuGuestAgent", enableQemuGuestAgent)
 
 		cmd.SetContext(ctx)
 
@@ -348,6 +351,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&vzUnsafeVolumeByName, "vz-unsafe-volume-by-name", false, "Only use the name to find a volume - workaround for virtuozzu - dangerous option")
 
     rootCmd.PersistentFlags().StringVar(&osType, "os-type", "", "Set os_type in the volume (image) metadata, (if set to \"auto\", it tries to detect the type from VMware GuestId)")
+
+    rootCmd.PersistentFlags().BoolVar(&enableQemuGuestAgent, "enable-qemu-guest-agent", false, "Sets the hw_qemu_guest_agent metadata parameter to yes")
 
 	cutoverCmd.Flags().StringVar(&flavorId, "flavor", "", "OpenStack Flavor ID")
 	cutoverCmd.MarkFlagRequired("flavor")


### PR DESCRIPTION
Adds the enable-qemu-guest-agent parameter and sets "hw_qemu_guest_agent" to yes if set. Fixes issue #73 .

IMPORTANT:
This PR depends on the changes in #70, since it relies on the changes how "volumeImageMetadata" are handled.