### PR TITLE
Closes Issue #133 -  removes required vmware-password argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,9 @@ import (
 	"net/url"
 	"os"
 	"time"
-
+	"fmt"
+	"golang.org/x/term"
+        "strings"
 	"github.com/erikgeiser/promptkit/confirmation"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	log "github.com/sirupsen/logrus"
@@ -81,6 +83,22 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if debug {
 			log.SetLevel(log.DebugLevel)
+		}
+
+		if password == "" {
+		    if !term.IsTerminal(int(os.Stdin.Fd())) {
+		        return fmt.Errorf("password is required but terminal is not interactive; please provide --vmware-password flag")
+		    }
+		    fmt.Print("Enter VMware Password: ")
+		    
+		    // ReadPassword hides the user's typing for security
+		    bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+		    if err != nil {
+		        fmt.Fprintf(os.Stderr, "Error reading password: %v\n", err)
+		        return err
+		    }
+		    password = strings.TrimSpace(string(bytePassword))
+		    fmt.Println() // Add a newline since ReadPassword doesn't print one
 		}
 
 		endpointUrl := &url.URL{

--- a/main.go
+++ b/main.go
@@ -353,7 +353,6 @@ func init() {
 	rootCmd.MarkPersistentFlagRequired("vmware-username")
 
 	rootCmd.PersistentFlags().StringVar(&password, "vmware-password", "", "VMware password")
-	rootCmd.MarkPersistentFlagRequired("vmware-password")
 
 	rootCmd.PersistentFlags().StringVar(&path, "vmware-path", "", "VMware VM path (e.g. '/Datacenter/vm/VM')")
 	rootCmd.MarkPersistentFlagRequired("vmware-path")


### PR DESCRIPTION
removes required vmware-password argument

--vmware-password becomes optional.

if supplied, works normally.

if not supplied, interactive prompt for password appears

if not interactive, returns error.

I'm not exactly the worlds best developer, and am very new to golang, so be kind, feel free to improve. 

We are using this fork locally.