### PR TITLE
fix(nbdkit): scope VDDK library path to nbdkit

### DIFF
--- a/internal/nbdkit/builder.go
+++ b/internal/nbdkit/builder.go
@@ -79,7 +79,6 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 	socket := fmt.Sprintf("%s/nbdkit.sock", tmp)
 	pidFile := fmt.Sprintf("%s/nbdkit.pid", tmp)
 
-	os.Setenv("LD_LIBRARY_PATH", "/usr/lib64/vmware-vix-disklib/lib64")
 	cmd := exec.Command(
 		"nbdkit",
 		"--exit-with-parent",
@@ -98,6 +97,7 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 		"transports=file:nbdssl:nbd",
 		b.filename,
 	)
+	cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH=/usr/lib64/vmware-vix-disklib/lib64")
 
 	return &NbdkitServer{
 		cmd:     cmd,


### PR DESCRIPTION
This scopes `LD_LIBRARY_PATH` to the `nbdkit` child process instead of mutating the migratekit process environment globally.

The VDDK plugin needs `/usr/lib64/vmware-vix-disklib/lib64` on the library search path, but setting it with `os.Setenv` causes the value to leak into later child processes.

In particular, this affects `virt-v2v-in-place` / `supermin`, where VMware's bundled OpenSSL libraries may be preferred over Fedora's system libraries and cause the symbol lookup failure reported in #153:

```text
/usr/bin/supermin: symbol lookup error: /lib64/librpm_sequoia.so.1:
undefined symbol: EVP_idea_cfb64, version OPENSSL_3.0.0
```
Using `cmd.Env` keeps the VDDK library path limited to the `nbdkit` invocation.

Fixes #153