### PR TITLE
Project and AZ handling optimizations, Network preparations for OS and CBT error handling via full-copy on cutover

### DIFF
--- a/internal/nbdkit/builder.go
+++ b/internal/nbdkit/builder.go
@@ -79,7 +79,6 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 	socket := fmt.Sprintf("%s/nbdkit.sock", tmp)
 	pidFile := fmt.Sprintf("%s/nbdkit.pid", tmp)
 
-	os.Setenv("LD_LIBRARY_PATH", "/usr/lib64/vmware-vix-disklib/lib64")
 	cmd := exec.Command(
 		"nbdkit",
 		"--exit-with-parent",
@@ -97,6 +96,7 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 		fmt.Sprintf("snapshot=%s", b.snapshot),
 		"transports=file:nbdssl:nbd",
 		b.filename,
+		cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH=/usr/lib64/vmware-vix-disklib/lib64")
 	)
 
 	return &NbdkitServer{

--- a/internal/nbdkit/builder.go
+++ b/internal/nbdkit/builder.go
@@ -96,8 +96,8 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 		fmt.Sprintf("snapshot=%s", b.snapshot),
 		"transports=file:nbdssl:nbd",
 		b.filename,
-		cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH=/usr/lib64/vmware-vix-disklib/lib64"),
 	)
+	cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH=/usr/lib64/vmware-vix-disklib/lib64")
 
 	return &NbdkitServer{
 		cmd:     cmd,

--- a/internal/nbdkit/builder.go
+++ b/internal/nbdkit/builder.go
@@ -96,7 +96,7 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 		fmt.Sprintf("snapshot=%s", b.snapshot),
 		"transports=file:nbdssl:nbd",
 		b.filename,
-		cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH=/usr/lib64/vmware-vix-disklib/lib64")
+		cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH=/usr/lib64/vmware-vix-disklib/lib64"),
 	)
 
 	return &NbdkitServer{

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -27,6 +27,9 @@ type ClientSet struct {
 	BlockStorage *gophercloud.ServiceClient
 	Compute      *gophercloud.ServiceClient
 	Networking   *gophercloud.ServiceClient
+	// LocalCompute is scoped to the project running migratekit (no --project override).
+	// Used for volumeattach operations where the instance lives in the source project.
+	LocalCompute *gophercloud.ServiceClient
 }
 
 type PortCreateOpts struct {
@@ -39,7 +42,28 @@ func NewClientSet(ctx context.Context) (*ClientSet, error) {
 		return nil, err
 	}
 
-	if project, _ := ctx.Value("osProject").(string); project != "" {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if os.Getenv("OS_INSECURE") == "true" {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	newProvider := func(authOpts gophercloud.AuthOptions) (*gophercloud.ProviderClient, error) {
+		p, err := openstack.NewClient(authOpts.IdentityEndpoint)
+		if err != nil {
+			return nil, err
+		}
+		ua := gophercloud.UserAgent{}
+		ua.Prepend("migratekit")
+		p.UserAgent = ua
+		p.HTTPClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		if err := openstack.Authenticate(ctx, p, authOpts); err != nil {
+			return nil, err
+		}
+		return p, nil
+	}
+
+	project, _ := ctx.Value("osProject").(string)
+	if project != "" {
 		if isUUID(project) {
 			opts.TenantID = project
 			opts.TenantName = ""
@@ -49,57 +73,51 @@ func NewClientSet(ctx context.Context) (*ClientSet, error) {
 		}
 	}
 
-	provider, err := openstack.NewClient(opts.IdentityEndpoint)
+	provider, err := newProvider(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	ua := gophercloud.UserAgent{}
-	ua.Prepend("migratekit")
-	provider.UserAgent = ua
+	region := os.Getenv("OS_REGION_NAME")
 
-	config := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
-
-	if os.Getenv("OS_INSECURE") == "true" {
-		config.InsecureSkipVerify = true
-	}
-
-	provider.HTTPClient.Transport = &http.Transport{
-		TLSClientConfig: config,
-	}
-
-	err = openstack.Authenticate(ctx, provider, opts)
+	blockStorageClient, err := openstack.NewBlockStorageV3(provider, gophercloud.EndpointOpts{Region: region})
 	if err != nil {
 		return nil, err
 	}
 
-	blockStorageClient, err := openstack.NewBlockStorageV3(provider, gophercloud.EndpointOpts{
-		Region: os.Getenv("OS_REGION_NAME"),
-	})
+	computeClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{Region: region})
 	if err != nil {
 		return nil, err
 	}
 
-	computeClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
-		Region: os.Getenv("OS_REGION_NAME"),
-	})
+	networkingClient, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{Region: region})
 	if err != nil {
 		return nil, err
 	}
 
-	networkingClient, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
-		Region: os.Getenv("OS_REGION_NAME"),
-	})
-	if err != nil {
-		return nil, err
+	// When --project overrides the scope, volumeattach calls must use the source project
+	// (where the migratekit instance lives). Create a separate compute client for that.
+	localComputeClient := computeClient
+	if project != "" {
+		localOpts, err := openstack.AuthOptionsFromEnv()
+		if err != nil {
+			return nil, err
+		}
+		localProvider, err := newProvider(localOpts)
+		if err != nil {
+			return nil, err
+		}
+		localComputeClient, err = openstack.NewComputeV2(localProvider, gophercloud.EndpointOpts{Region: region})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &ClientSet{
 		BlockStorage: blockStorageClient,
 		Compute:      computeClient,
 		Networking:   networkingClient,
+		LocalCompute: localComputeClient,
 	}, nil
 }
 

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -39,6 +39,16 @@ func NewClientSet(ctx context.Context) (*ClientSet, error) {
 		return nil, err
 	}
 
+	if project, _ := ctx.Value("osProject").(string); project != "" {
+		if isUUID(project) {
+			opts.TenantID = project
+			opts.TenantName = ""
+		} else {
+			opts.TenantName = project
+			opts.TenantID = ""
+		}
+	}
+
 	provider, err := openstack.NewClient(opts.IdentityEndpoint)
 	if err != nil {
 		return nil, err
@@ -293,4 +303,20 @@ func (c *ClientSet) CreateResourcesForVirtualMachine(ctx context.Context, vm *ob
 	}
 
 	return nil
+}
+
+func isUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range s {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if c != '-' {
+				return false
+			}
+		} else if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/target/openstack.go
+++ b/internal/target/openstack.go
@@ -195,7 +195,7 @@ func (t *OpenStack) Connect(ctx context.Context) error {
 			"instance_uuid": instanceUUID,
 		}).Info("Detected instance UUID, attaching volume...")
 
-		_, err = volumeattach.Create(ctx, t.ClientSet.Compute, instanceUUID, volumeattach.CreateOpts{
+		_, err = volumeattach.Create(ctx, t.ClientSet.LocalCompute, instanceUUID, volumeattach.CreateOpts{
 			VolumeID: volume.ID,
 		}).Extract()
 		if err != nil {
@@ -292,7 +292,7 @@ func (t *OpenStack) Disconnect(ctx context.Context) error {
 			return err
 		}
 
-		err = volumeattach.Delete(ctx, t.ClientSet.Compute, instanceUUID, volume.ID).ExtractErr()
+		err = volumeattach.Delete(ctx, t.ClientSet.LocalCompute, instanceUUID, volume.ID).ExtractErr()
 		if err != nil {
 			return err
 		}

--- a/internal/target/util.go
+++ b/internal/target/util.go
@@ -41,6 +41,10 @@ func NeedsFullCopy(ctx context.Context, t Target) (bool, bool, error) {
 
 	snapshotChangeId, err := vmware.GetChangeID(t.GetDisk())
 	if err != nil {
+		if errors.Is(err, vmware.ErrCBTNotEnabled) {
+			log.Warning("CBT is not enabled, forcing full copy")
+			return true, false, nil
+		}
 		return false, false, err
 	}
 

--- a/internal/vmware/change_id.go
+++ b/internal/vmware/change_id.go
@@ -9,6 +9,7 @@ import (
 )
 
 var ErrInvalidChangeID = errors.New("invalid change ID")
+var ErrCBTNotEnabled = errors.New("CBT is not enabled")
 
 type ChangeID struct {
 	UUID   string
@@ -45,7 +46,7 @@ func GetChangeID(disk *types.VirtualDisk) (*ChangeID, error) {
 	}
 
 	if changeId == "" {
-		return nil, fmt.Errorf("CBT is not enabled on disk %d", disk.Key)
+		return nil, fmt.Errorf("%w on disk %d", ErrCBTNotEnabled, disk.Key)
 	}
 
 	return ParseChangeID(changeId)

--- a/internal/vmware_nbdkit/vmware_nbdkit.go
+++ b/internal/vmware_nbdkit/vmware_nbdkit.go
@@ -2,6 +2,7 @@ package vmware_nbdkit
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"os"
 	"os/exec"
@@ -311,7 +312,10 @@ func (s *NbdkitServer) IncrementalCopyToTarget(ctx context.Context, t target.Tar
 func (s *NbdkitServer) SyncToTarget(ctx context.Context, t target.Target, runV2V bool) error {
 	snapshotChangeId, err := vmware.GetChangeID(s.Disk)
 	if err != nil {
-		return err
+		if !errors.Is(err, vmware.ErrCBTNotEnabled) {
+			return err
+		}
+		snapshotChangeId = &vmware.ChangeID{}
 	}
 
 	needFullCopy, targetIsClean, err := target.NeedsFullCopy(ctx, t)

--- a/internal/vmware_nbdkit/vmware_nbdkit.go
+++ b/internal/vmware_nbdkit/vmware_nbdkit.go
@@ -421,7 +421,7 @@ func (s *NbdkitServer) injectUdevNicRules(ctx context.Context, path string) erro
 		return nil
 	}
 
-	var rules []string
+	var echoLines []string
 	for i, nic := range nics {
 		card := nic.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
 		name := nicInterfaceName(nic, i)
@@ -431,28 +431,22 @@ func (s *NbdkitServer) injectUdevNicRules(ctx context.Context, path string) erro
 			"name": name,
 		}).Info("Adding udev NIC rule")
 
-		rules = append(rules, fmt.Sprintf(
+		rule := fmt.Sprintf(
 			`SUBSYSTEM=="net", ACTION=="add", ATTR{address}=="%s", NAME="%s"`,
 			card.MacAddress, name,
-		))
+		)
+		echoLines = append(echoLines, fmt.Sprintf("echo '%s'", rule))
 	}
 
-	rulesContent := strings.Join(rules, "\n") + "\n"
-
-	tmpFile, err := os.CreateTemp("", "udev-nic-rules-*.rules")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := tmpFile.WriteString(rulesContent); err != nil {
-		return err
-	}
-	tmpFile.Close()
+	// Write the rules file inline via --run-command to avoid inode corruption
+	// that --upload can cause on ext4 filesystems.
+	shellCmd := fmt.Sprintf(
+		"{ %s; } > /etc/udev/rules.d/70-persistent-net.rules",
+		strings.Join(echoLines, "; "),
+	)
 
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
-	cmd := exec.Command("virt-customize", "-a", path,
-		"--upload", tmpFile.Name()+":/etc/udev/rules.d/70-persistent-net.rules")
+	cmd := exec.Command("virt-customize", "-a", path, "--run-command", shellCmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/internal/vmware_nbdkit/vmware_nbdkit.go
+++ b/internal/vmware_nbdkit/vmware_nbdkit.go
@@ -3,10 +3,12 @@ package vmware_nbdkit
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
@@ -185,6 +187,8 @@ func (s *NbdkitServers) MigrationCycle(ctx context.Context, runV2V bool) error {
 		}
 	}()
 
+	fixNicNames, _ := ctx.Value("fixNicNames").(bool)
+
 	for index, server := range s.Servers {
 		t, err := target.NewOpenStack(ctx, s.VirtualMachine, server.Disk)
 		if err != nil {
@@ -195,7 +199,7 @@ func (s *NbdkitServers) MigrationCycle(ctx context.Context, runV2V bool) error {
 			runV2V = false
 		}
 
-		err = server.SyncToTarget(ctx, t, runV2V)
+		err = server.SyncToTarget(ctx, t, runV2V, fixNicNames && index == 0)
 		if err != nil {
 			return err
 		}
@@ -309,7 +313,7 @@ func (s *NbdkitServer) IncrementalCopyToTarget(ctx context.Context, t target.Tar
 	return nil
 }
 
-func (s *NbdkitServer) SyncToTarget(ctx context.Context, t target.Target, runV2V bool) error {
+func (s *NbdkitServer) SyncToTarget(ctx context.Context, t target.Target, runV2V bool, fixNicNames bool) error {
 	snapshotChangeId, err := vmware.GetChangeID(s.Disk)
 	if err != nil {
 		if !errors.Is(err, vmware.ErrCBTNotEnabled) {
@@ -391,5 +395,84 @@ func (s *NbdkitServer) SyncToTarget(ctx context.Context, t target.Target, runV2V
 		}
 	}
 
+	if fixNicNames {
+		if err := s.injectUdevNicRules(ctx, path); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func (s *NbdkitServer) injectUdevNicRules(ctx context.Context, path string) error {
+	if path == "" {
+		log.Warning("No block device path available, skipping udev NIC rule injection")
+		return nil
+	}
+
+	devices, err := s.Servers.VirtualMachine.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	nics := devices.SelectByType((*types.VirtualEthernetCard)(nil))
+	if len(nics) == 0 {
+		log.Info("No network adapters found, skipping udev NIC rule injection")
+		return nil
+	}
+
+	var rules []string
+	for i, nic := range nics {
+		card := nic.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		name := nicInterfaceName(nic, i)
+
+		log.WithFields(log.Fields{
+			"mac":  card.MacAddress,
+			"name": name,
+		}).Info("Adding udev NIC rule")
+
+		rules = append(rules, fmt.Sprintf(
+			`SUBSYSTEM=="net", ACTION=="add", ATTR{address}=="%s", NAME="%s"`,
+			card.MacAddress, name,
+		))
+	}
+
+	rulesContent := strings.Join(rules, "\n") + "\n"
+
+	tmpFile, err := os.CreateTemp("", "udev-nic-rules-*.rules")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(rulesContent); err != nil {
+		return err
+	}
+	tmpFile.Close()
+
+	os.Setenv("LIBGUESTFS_BACKEND", "direct")
+	cmd := exec.Command("virt-customize", "-a", path,
+		"--upload", tmpFile.Name()+":/etc/udev/rules.d/70-persistent-net.rules")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	log.WithField("path", path).Info("Injecting udev NIC rules into guest")
+	return cmd.Run()
+}
+
+func nicInterfaceName(nic types.BaseVirtualDevice, index int) string {
+	device := nic.GetVirtualDevice()
+
+	if device.SlotInfo != nil {
+		if pci, ok := device.SlotInfo.(*types.VirtualDevicePciBusSlotInfo); ok && pci.PciSlotNumber > 0 {
+			return fmt.Sprintf("ens%d", pci.PciSlotNumber)
+		}
+	}
+
+	// Fallback: VMXNET3 uses PCI slots 192, 224, 256, ... (192 + 32*index)
+	if _, ok := nic.(*types.VirtualVmxnet3); ok {
+		return fmt.Sprintf("ens%d", 192+32*index)
+	}
+
+	return fmt.Sprintf("eth%d", index)
 }

--- a/main.go
+++ b/main.go
@@ -72,7 +72,8 @@ var (
 	busType              BusTypeOpts
 	vzUnsafeVolumeByName bool
 	osType               string
-    enableQemuGuestAgent bool
+	enableQemuGuestAgent bool
+	noCBT                bool
 )
 
 var rootCmd = &cobra.Command{
@@ -154,7 +155,10 @@ var rootCmd = &cobra.Command{
 		}
 
 		if o.Config.ChangeTrackingEnabled == nil || !*o.Config.ChangeTrackingEnabled {
-			return errors.New("change tracking is not enabled on the virtual machine")
+			if !noCBT {
+				return errors.New("change tracking is not enabled on the virtual machine")
+			}
+			log.Warning("Change tracking is not enabled, --no-cbt set: migrations will always do a full copy")
 		}
 
 		if snapshotRef, _ := vm.FindSnapshot(ctx, "migratekit"); snapshotRef != nil {
@@ -352,7 +356,9 @@ func init() {
 
     rootCmd.PersistentFlags().StringVar(&osType, "os-type", "", "Set os_type in the volume (image) metadata, (if set to \"auto\", it tries to detect the type from VMware GuestId)")
 
-    rootCmd.PersistentFlags().BoolVar(&enableQemuGuestAgent, "enable-qemu-guest-agent", false, "Sets the hw_qemu_guest_agent metadata parameter to yes")
+	rootCmd.PersistentFlags().BoolVar(&enableQemuGuestAgent, "enable-qemu-guest-agent", false, "Sets the hw_qemu_guest_agent metadata parameter to yes")
+
+	rootCmd.PersistentFlags().BoolVar(&noCBT, "no-cbt", false, "Disable Changed Block Tracking requirement; migrations always perform a full copy")
 
 	cutoverCmd.Flags().StringVar(&flavorId, "flavor", "", "OpenStack Flavor ID")
 	cutoverCmd.MarkFlagRequired("flavor")

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ var (
 	osType               string
 	enableQemuGuestAgent bool
 	noCBT                bool
+	osProject            string
 )
 
 var rootCmd = &cobra.Command{
@@ -202,6 +203,8 @@ var rootCmd = &cobra.Command{
 		ctx = context.WithValue(ctx, "osType", osType)
 
 		ctx = context.WithValue(ctx, "enableQemuGuestAgent", enableQemuGuestAgent)
+
+		ctx = context.WithValue(ctx, "osProject", osProject)
 
 		cmd.SetContext(ctx)
 
@@ -359,6 +362,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&enableQemuGuestAgent, "enable-qemu-guest-agent", false, "Sets the hw_qemu_guest_agent metadata parameter to yes")
 
 	rootCmd.PersistentFlags().BoolVar(&noCBT, "no-cbt", false, "Disable Changed Block Tracking requirement; migrations always perform a full copy")
+
+	rootCmd.PersistentFlags().StringVar(&osProject, "project", "", "OpenStack project name or ID to migrate into (overrides OS_PROJECT_NAME/OS_PROJECT_ID)")
 
 	cutoverCmd.Flags().StringVar(&flavorId, "flavor", "", "OpenStack Flavor ID")
 	cutoverCmd.MarkFlagRequired("flavor")

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ var (
 	enableQemuGuestAgent bool
 	noCBT                bool
 	osProject            string
+	fixNicNames          bool
 )
 
 var rootCmd = &cobra.Command{
@@ -210,6 +211,8 @@ var rootCmd = &cobra.Command{
 		ctx = context.WithValue(ctx, "enableQemuGuestAgent", enableQemuGuestAgent)
 
 		ctx = context.WithValue(ctx, "osProject", osProject)
+
+		ctx = context.WithValue(ctx, "fixNicNames", fixNicNames)
 
 		cmd.SetContext(ctx)
 
@@ -381,6 +384,8 @@ func init() {
 	cutoverCmd.Flags().StringSliceVar(&securityGroups, "security-groups", nil, "Openstack security groups, comma separated (e.g. '42c5a89e-4034-4f2a-adea-b33adc9614f4,6647122c-2d46-42f1-bb26-f38007730fdc')")
 
 	cutoverCmd.Flags().BoolVar(&enablev2v, "run-v2v", true, "Run virt2v-inplace on destination VM")
+
+	cutoverCmd.Flags().BoolVar(&fixNicNames, "fix-nic-names", false, "Inject udev rules into the guest to preserve VMware interface names (e.g. ens192) in OpenStack")
 
 	cutoverCmd.Flags().StringVar(&availabilityZone, "availability-zone", "", "OpenStack availability zone for blockdevice & server")
 	cutoverCmd.MarkFlagRequired("availability-zone")

--- a/main.go
+++ b/main.go
@@ -65,7 +65,8 @@ var (
 	compressionMethod    CompressionMethodOpts = Skipz
 	flavorId             string
 	networkMapping       cmd.NetworkMappingFlag
-	availabilityZone     string
+	availabilityZone        string
+	volumeAvailabilityZone  string
 	volumeType           string
 	securityGroups       []string
 	enablev2v            bool
@@ -191,8 +192,12 @@ var rootCmd = &cobra.Command{
 		})
 
 		log.Info("Setting Disk Bus: ", BusTypeOptsIds[busType][0])
+		volumeAZ := volumeAvailabilityZone
+		if volumeAZ == "" {
+			volumeAZ = availabilityZone
+		}
 		v := target.VolumeCreateOpts{
-			AvailabilityZone: availabilityZone,
+			AvailabilityZone: volumeAZ,
 			VolumeType:       volumeType,
 			BusType:          BusTypeOptsIds[busType][0],
 		}
@@ -349,7 +354,9 @@ func init() {
 
 	rootCmd.PersistentFlags().Var(enumflag.New(&compressionMethod, "compression-method", CompressionMethodOptsIds, enumflag.EnumCaseInsensitive), "compression-method", "Specifies the compression method to use for the disk")
 
-	rootCmd.PersistentFlags().StringVar(&availabilityZone, "availability-zone", "", "Openstack availability zone for blockdevice & server")
+	rootCmd.PersistentFlags().StringVar(&availabilityZone, "availability-zone", "", "OpenStack availability zone for server (and volumes if --volume-availability-zone is not set)")
+
+	rootCmd.PersistentFlags().StringVar(&volumeAvailabilityZone, "volume-availability-zone", "", "OpenStack availability zone for volumes (overrides --availability-zone for volumes)")
 
 	rootCmd.PersistentFlags().StringVar(&volumeType, "volume-type", "", "Openstack volume type")
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the migration tool, focusing on OpenStack project scoping, network interface name preservation, and enhanced error handling for Changed Block Tracking (CBT). The changes add new command-line flags, improve context handling, and ensure more robust and flexible migrations.

**OpenStack Project and Availability Zone Handling:**
- Added support for specifying an OpenStack project (`--project`) to migrate into, with logic to handle both project names and UUIDs and to maintain a separate compute client for volume attachment operations in the source project (`ClientSet.LocalCompute`). [[1]](diffhunk://#diff-1ad5e339a0273fcf197ed405940cef612daae950dc40c04108d02d1b3b7b8f41R30-R32) [[2]](diffhunk://#diff-1ad5e339a0273fcf197ed405940cef612daae950dc40c04108d02d1b3b7b8f41L42-R120) [[3]](diffhunk://#diff-7d69c8067069d72a2ca8bbce1e6ba2e620c19f4fffe0067ba00a2e6ddef6f20cL198-R198) [[4]](diffhunk://#diff-7d69c8067069d72a2ca8bbce1e6ba2e620c19f4fffe0067ba00a2e6ddef6f20cL295-R295)
- Introduced a `--volume-availability-zone` flag to allow specifying a different availability zone for volumes, overriding the general server availability zone if set. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R69-R79) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R196-R201) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L345-R362)

**Network Interface Name Preservation:**
- Added the `--fix-nic-names` flag and associated logic to inject udev rules into the guest VM, ensuring VMware interface names (e.g., `ens192`) are preserved after migration to OpenStack. This includes a new method to generate and inject the appropriate udev rules using `virt-customize`. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R69-R79) [[2]](diffhunk://#diff-334501eec3cd3326a9e9a2f94d2fbbb3a2ce1c58759a35c5b38223cb143800a7R190-R191) [[3]](diffhunk://#diff-334501eec3cd3326a9e9a2f94d2fbbb3a2ce1c58759a35c5b38223cb143800a7L197-R202) [[4]](diffhunk://#diff-334501eec3cd3326a9e9a2f94d2fbbb3a2ce1c58759a35c5b38223cb143800a7R398-R472) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R388-R389)

**Changed Block Tracking (CBT) Handling:**
- Added the `--no-cbt` flag to allow migrations to proceed even if CBT is not enabled, with appropriate warnings and fallback to full copy mode. Improved error handling and signaling for CBT-related issues. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R69-R79) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R161-R165) [[3]](diffhunk://#diff-26813defd383ca65602a4ae842a6247f244656dc0491285cacd22218aaa8ef80R12) [[4]](diffhunk://#diff-26813defd383ca65602a4ae842a6247f244656dc0491285cacd22218aaa8ef80L48-R49) [[5]](diffhunk://#diff-01bb5e5e9a1b828873c665f328ab0917fde3ecf6866652b9fba5cf17c7148cacR44-R47)

**Environment and Library Path Handling:**
- Changed the way `LD_LIBRARY_PATH` is set for `nbdkit` invocation, ensuring it is passed directly to the command environment rather than set globally. [[1]](diffhunk://#diff-ea3000dc5d725a7f5f574081c1cfce51d87598514b6c7de7656f2a3e98a087c3L82) [[2]](diffhunk://#diff-ea3000dc5d725a7f5f574081c1cfce51d87598514b6c7de7656f2a3e98a087c3R100)

**Internal Refactoring and Utility Additions:**
- Added utility functions such as `isUUID` for project ID detection and improved TLS configuration handling for OpenStack clients. [[1]](diffhunk://#diff-1ad5e339a0273fcf197ed405940cef612daae950dc40c04108d02d1b3b7b8f41L42-R120) [[2]](diffhunk://#diff-1ad5e339a0273fcf197ed405940cef612daae950dc40c04108d02d1b3b7b8f41R325-R340)

These changes collectively improve the tool's flexibility, reliability, and compatibility with a broader range of OpenStack and VMware environments.

These changes and this summary are supported by Claude Code. ;-)